### PR TITLE
Optimize NewMovie Refresh Logic

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,11 +41,6 @@ android {
         }
     }
 
-    compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
-    }
-
     // Always show the result of every unit test, even if it passes.
     testOptions.unitTests.all {
         testLogging {
@@ -74,7 +69,7 @@ android {
 
 dependencies {
     annotationProcessor "com.jakewharton:butterknife-compiler:8.8.1"
-    annotationProcessor "android.arch.lifecycle:compiler:1.1.0"
+    annotationProcessor "android.arch.lifecycle:compiler:1.1.1"
     annotationProcessor "android.arch.persistence.room:compiler:1.0.0"
     annotationProcessor 'com.google.dagger:dagger-android-processor:2.14.1'
     annotationProcessor 'com.google.dagger:dagger-compiler:2.14.1'
@@ -92,11 +87,11 @@ dependencies {
     implementation 'com.android.support:design:27.1.0'
     implementation 'com.android.support:recyclerview-v7:27.1.0'
     implementation 'com.android.support.test.espresso:espresso-idling-resource:3.0.1'
-    implementation 'android.arch.lifecycle:extensions:1.1.0'
-    implementation 'android.arch.lifecycle:viewmodel:1.1.0'
-    implementation 'android.arch.lifecycle:livedata:1.1.0'
+    implementation 'android.arch.lifecycle:extensions:1.1.1'
+    implementation 'android.arch.lifecycle:viewmodel:1.1.1'
+    implementation 'android.arch.lifecycle:livedata:1.1.1'
     implementation 'android.arch.persistence.room:runtime:1.0.0'
-    implementation 'android.arch.paging:runtime:1.0.0-alpha6'
+    implementation 'android.arch.paging:runtime:1.0.0-alpha7'
     implementation 'org.jsoup:jsoup:1.8.3'
     implementation 'com.google.dagger:dagger:2.14.1'
     implementation 'com.google.dagger:dagger-android:2.14.1'
@@ -104,7 +99,7 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.6.1'
     implementation 'com.android.support:palette-v7:27.1.0'
     implementation 'com.github.florent37:glidepalette:2.1.2'
-    implementation 'com.google.android.gms:play-services-ads:11.8.0'
+    implementation 'com.google.android.gms:play-services-ads:12.0.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.7.19'
@@ -124,7 +119,7 @@ dependencies {
     androidTestImplementation 'com.android.support:design:27.1.0'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-contrib:3.0.1'
-    androidTestImplementation 'android.arch.core:core-testing:1.1.0'
+    androidTestImplementation 'android.arch.core:core-testing:1.1.1'
     androidTestImplementation 'org.mockito:mockito-core:2.7.19'
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:2.2.0'
 }

--- a/app/schemas/com.bzh.dytt.data.db.AppDatabase/1.json
+++ b/app/schemas/com.bzh.dytt.data.db.AppDatabase/1.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "0976168e1ac66b0c337e986bec16d04f",
+    "identityHash": "686395d0e3dda8f85da82c65c2a31e60",
     "entities": [
       {
         "tableName": "homeareas",
@@ -253,7 +253,7 @@
       },
       {
         "tableName": "category_map",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category` INTEGER NOT NULL, `link` TEXT NOT NULL, PRIMARY KEY(`category`, `link`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`category` INTEGER NOT NULL, `link` TEXT NOT NULL, `is_parsed` INTEGER NOT NULL, PRIMARY KEY(`category`, `link`))",
         "fields": [
           {
             "fieldPath": "mCategory",
@@ -265,6 +265,12 @@
             "fieldPath": "mLink",
             "columnName": "link",
             "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mIsParsed",
+            "columnName": "is_parsed",
+            "affinity": "INTEGER",
             "notNull": true
           }
         ],
@@ -281,7 +287,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"0976168e1ac66b0c337e986bec16d04f\")"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"686395d0e3dda8f85da82c65c2a31e60\")"
     ]
   }
 }

--- a/app/src/main/java/com/bzh/dytt/BaseFragment.java
+++ b/app/src/main/java/com/bzh/dytt/BaseFragment.java
@@ -5,7 +5,6 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,7 +13,7 @@ import com.bzh.dytt.di.Injectable;
 
 import butterknife.ButterKnife;
 
-public abstract class BaseFragment extends Fragment  implements Injectable {
+public abstract class BaseFragment extends Fragment implements Injectable {
 
     @Override
     public final void onCreate(@Nullable Bundle savedInstanceState) {

--- a/app/src/main/java/com/bzh/dytt/DataRepository.java
+++ b/app/src/main/java/com/bzh/dytt/DataRepository.java
@@ -70,17 +70,22 @@ public class DataRepository {
                     List<CategoryMap> categoryMaps = mHomePageParser.parseLatestMovieCategoryMap(item);
                     mAppDatabase.categoryMapDAO().insertCategoryMapList(categoryMaps);
 
-                    List<VideoDetail> details = new ArrayList<>();
+                                      List<VideoDetail> details = new ArrayList<>();
                     for (int i = categoryMaps.size() - 1; i >= 0; i--) {
                         VideoDetail videoDetail = new VideoDetail();
+                        CategoryMap category = categoryMaps.get(i);
+                        videoDetail.setDetailLink(category.getLink());
+                        details.add(videoDetail);
+                    }
+                    mAppDatabase.videoDetailDAO().insertVideoDetailList(details);
+
+                    for (int i = categoryMaps.size() - 1; i >= 0; i--) {
                         CategoryMap category = categoryMaps.get(i);
                         boolean isParsed = mAppDatabase.categoryMapDAO().IsParsed(category.getLink());
                         if (!isParsed) {
                             getVideoDetailNew(category);
-                            details.add(videoDetail);
                         }
                     }
-                    mAppDatabase.videoDetailDAO().insertVideoDetailList(details);
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -121,13 +126,18 @@ public class DataRepository {
                     for (int i = categoryMaps.size() - 1; i >= 0; i--) {
                         VideoDetail videoDetail = new VideoDetail();
                         CategoryMap category = categoryMaps.get(i);
+                        videoDetail.setDetailLink(category.getLink());
+                        details.add(videoDetail);
+                    }
+                    mAppDatabase.videoDetailDAO().insertVideoDetailList(details);
+
+                    for (int i = categoryMaps.size() - 1; i >= 0; i--) {
+                        CategoryMap category = categoryMaps.get(i);
                         boolean isParsed = mAppDatabase.categoryMapDAO().IsParsed(category.getLink());
                         if (!isParsed) {
                             getVideoDetailNew(category);
-                            details.add(videoDetail);
                         }
                     }
-                    mAppDatabase.videoDetailDAO().insertVideoDetailList(details);
 
                 } catch (IOException e) {
                     e.printStackTrace();

--- a/app/src/main/java/com/bzh/dytt/MainActivity.java
+++ b/app/src/main/java/com/bzh/dytt/MainActivity.java
@@ -170,7 +170,7 @@ public class MainActivity extends AppCompatActivity
 
         @Override
         public int getCount() {
-            return 3;
+            return 1;
         }
     }
 }

--- a/app/src/main/java/com/bzh/dytt/MainActivity.java
+++ b/app/src/main/java/com/bzh/dytt/MainActivity.java
@@ -14,7 +14,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 
 import com.bzh.dytt.colorhunt.ColorHuntFragment;
-import com.bzh.dytt.girl.GirlFragment;
 import com.bzh.dytt.home.AllMoviePageFragment;
 import com.bzh.dytt.home.NewMovieFragment;
 import com.bzh.dytt.view.NonInteractiveViewPage;
@@ -34,11 +33,9 @@ import dagger.android.support.HasSupportFragmentInjector;
 public class MainActivity extends AppCompatActivity
         implements NavigationView.OnNavigationItemSelectedListener, HasSupportFragmentInjector {
 
+    private static final String TAG = "MainActivity";
     @Inject
     DispatchingAndroidInjector<Fragment> fragmentInjector;
-
-    private static final String TAG = "MainActivity";
-
     @BindView(R.id.toolbar)
     Toolbar mToolbar;
 
@@ -135,8 +132,7 @@ public class MainActivity extends AppCompatActivity
         if (id == R.id.nav_home) {
             mToolbar.setTitle(R.string.nav_home_page);
             mContainer.setCurrentItem(0);
-        }
-        else if (id == R.id.nav_movie) {
+        } else if (id == R.id.nav_movie) {
             mToolbar.setTitle(R.string.nav_movie_page);
             mContainer.setCurrentItem(1);
         } else if (id == R.id.nav_imdb) {

--- a/app/src/main/java/com/bzh/dytt/data/CategoryMap.java
+++ b/app/src/main/java/com/bzh/dytt/data/CategoryMap.java
@@ -19,6 +19,9 @@ public class CategoryMap {
     @NonNull
     private String mLink;
 
+    @ColumnInfo(name = "is_parsed")
+    private boolean mIsParsed;
+
     public String getLink() {
         return mLink;
     }
@@ -33,5 +36,31 @@ public class CategoryMap {
 
     public void setCategory(int category) {
         mCategory = category;
+    }
+
+    public void setIsParsed(boolean mIsParsed) {
+        this.mIsParsed = mIsParsed;
+    }
+
+    public boolean getIsParsed() {
+        return mIsParsed;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CategoryMap that = (CategoryMap) o;
+
+        if (mCategory != that.mCategory) return false;
+        return mLink.equals(that.mLink);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mCategory;
+        result = 31 * result + mLink.hashCode();
+        return result;
     }
 }

--- a/app/src/main/java/com/bzh/dytt/data/CategoryMap.java
+++ b/app/src/main/java/com/bzh/dytt/data/CategoryMap.java
@@ -9,7 +9,6 @@ import android.support.annotation.NonNull;
         tableName = "category_map",
         primaryKeys = {"category", "link"}
 )
-
 public class CategoryMap {
 
     @ColumnInfo(name = "category")
@@ -19,7 +18,6 @@ public class CategoryMap {
     @ColumnInfo(name = "link")
     @NonNull
     private String mLink;
-
 
     public String getLink() {
         return mLink;

--- a/app/src/main/java/com/bzh/dytt/data/VideoDetail.java
+++ b/app/src/main/java/com/bzh/dytt/data/VideoDetail.java
@@ -249,4 +249,12 @@ public class VideoDetail {
     public void setCategory(int category) {
         mCategory = category;
     }
+
+    @Override
+    public String toString() {
+        return "VideoDetail{" +
+                "mDetailLink='" + mDetailLink + '\'' +
+                ", mName='" + mName + '\'' +
+                '}';
+    }
 }

--- a/app/src/main/java/com/bzh/dytt/data/db/CategoryMapDAO.java
+++ b/app/src/main/java/com/bzh/dytt/data/db/CategoryMapDAO.java
@@ -5,12 +5,13 @@ import android.arch.lifecycle.LiveData;
 import android.arch.persistence.room.Dao;
 import android.arch.persistence.room.Insert;
 import android.arch.persistence.room.Query;
+import android.arch.persistence.room.Update;
 
 import com.bzh.dytt.data.CategoryMap;
-import com.bzh.dytt.data.VideoDetail;
 
 import java.util.List;
 
+import static android.arch.persistence.room.OnConflictStrategy.IGNORE;
 import static android.arch.persistence.room.OnConflictStrategy.REPLACE;
 
 @Dao
@@ -19,10 +20,15 @@ public interface CategoryMapDAO {
     @Insert(onConflict = REPLACE)
     void insertCategoryMap(CategoryMap categoryMap);
 
-    @Insert(onConflict = REPLACE)
+    @Insert(onConflict = IGNORE)
     void insertCategoryMapList(List<CategoryMap> categoryMapList);
 
     @Query("SELECT * FROM category_map WHERE category = :category ORDER BY rowid ASC")
     LiveData<List<CategoryMap>> getMovieLinksByCategory(int category);
 
+    @Update
+    void updateCategory(CategoryMap mCategoryMap);
+
+    @Query("SELECT is_parsed FROM category_map WHERE link = :link")
+    boolean IsParsed(String link);
 }

--- a/app/src/main/java/com/bzh/dytt/data/db/DatabaseResource.java
+++ b/app/src/main/java/com/bzh/dytt/data/db/DatabaseResource.java
@@ -18,6 +18,8 @@ import java.util.List;
 
 public abstract class DatabaseResource<ResultType> {
 
+    private static final String TAG = "DatabaseResource";
+
     private final AppExecutors mAppExecutors;
 
     private MediatorLiveData<Resource<ResultType>> result = new MediatorLiveData<>();

--- a/app/src/main/java/com/bzh/dytt/data/db/DatabaseResource.java
+++ b/app/src/main/java/com/bzh/dytt/data/db/DatabaseResource.java
@@ -14,7 +14,10 @@ import com.bzh.dytt.AppExecutors;
 import com.bzh.dytt.data.network.ApiResponse;
 import com.bzh.dytt.data.network.Resource;
 
+import java.util.List;
+
 public abstract class DatabaseResource<ResultType> {
+
     private final AppExecutors mAppExecutors;
 
     private MediatorLiveData<Resource<ResultType>> result = new MediatorLiveData<>();
@@ -23,26 +26,16 @@ public abstract class DatabaseResource<ResultType> {
     public DatabaseResource(AppExecutors appExecutors) {
         mAppExecutors = appExecutors;
 
-        result.setValue(Resource.loading(null));
+        result.setValue(Resource.<ResultType>loading(null));
 
         final LiveData<ResultType> dbSource = loadFromDb();
 
         result.addSource(dbSource, new Observer<ResultType>() {
             @Override
             public void onChanged(@Nullable ResultType newData) {
-//                result.removeSource(dbSource);
-//                result.addSource(loadFromDb(), new Observer<ResultType>() {
-//                    @Override
-//                    public void onChanged(@Nullable ResultType newData) {
-//                        Log.d("Yifan", "newData : " + newData);
-//                        result.setValue(Resource.success(newData));
-//                    }
-//                });
                 result.setValue(Resource.success(newData));
-
             }
         });
-
     }
 
     @NonNull

--- a/app/src/main/java/com/bzh/dytt/data/db/VideoDetailDAO.java
+++ b/app/src/main/java/com/bzh/dytt/data/db/VideoDetailDAO.java
@@ -20,9 +20,8 @@ public interface VideoDetailDAO {
     @Insert(onConflict = IGNORE)
     void insertVideoDetail(VideoDetail videoDetail);
 
-    @Insert(onConflict = REPLACE)
+    @Insert(onConflict = IGNORE)
     void insertVideoDetailList(List<VideoDetail> videoDetailList);
-
 
     @Update
     void updateVideoDetail(VideoDetail videoDetail);

--- a/app/src/main/java/com/bzh/dytt/data/network/DyttService.java
+++ b/app/src/main/java/com/bzh/dytt/data/network/DyttService.java
@@ -2,8 +2,6 @@ package com.bzh.dytt.data.network;
 
 import android.arch.lifecycle.LiveData;
 
-import com.bzh.dytt.data.VideoDetail;
-
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.GET;
@@ -14,7 +12,6 @@ public interface DyttService {
 
     @GET("/")
     LiveData<ApiResponse<ResponseBody>> getHomePage();
-
 
     @GET
     LiveData<ApiResponse<ResponseBody>> getHomePage2(@Url String url);

--- a/app/src/main/java/com/bzh/dytt/data/network/NetworkBoundResource.java
+++ b/app/src/main/java/com/bzh/dytt/data/network/NetworkBoundResource.java
@@ -7,11 +7,12 @@ import android.support.annotation.MainThread;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.WorkerThread;
-import android.util.Log;
 
 import com.bzh.dytt.AppExecutors;
 
 public abstract class NetworkBoundResource<ResultType, RequestType> {
+
+    private static final String TAG = "NetworkBoundResource";
 
     private final AppExecutors mAppExecutors;
 

--- a/app/src/main/java/com/bzh/dytt/data/network/NetworkBoundResource.java
+++ b/app/src/main/java/com/bzh/dytt/data/network/NetworkBoundResource.java
@@ -21,7 +21,7 @@ public abstract class NetworkBoundResource<ResultType, RequestType> {
     public NetworkBoundResource(AppExecutors appExecutors) {
         mAppExecutors = appExecutors;
 
-        result.setValue(Resource.loading(null));
+        result.setValue(Resource.<ResultType>loading(null));
 
         final LiveData<ResultType> dbSource = loadFromDb();
 

--- a/app/src/main/java/com/bzh/dytt/data/network/Resource.java
+++ b/app/src/main/java/com/bzh/dytt/data/network/Resource.java
@@ -5,6 +5,7 @@ import android.support.annotation.Nullable;
 
 /**
  * A generic class that holds a value with its loading status.
+ *
  * @param <T>
  */
 
@@ -29,11 +30,27 @@ public class Resource<T> {
         return new Resource<>(Status.SUCCESS, data, null);
     }
 
+    public static <T> Resource<T> success(@NonNull T data, @Nullable String message) {
+        return new Resource<>(Status.SUCCESS, data, message);
+    }
+
     public static <T> Resource<T> error(String msg, @Nullable T data) {
         return new Resource<>(Status.ERROR, data, msg);
     }
 
     public static <T> Resource<T> loading(@Nullable T data) {
         return new Resource<>(Status.LOADING, data, null);
+    }
+
+    public static <T> Resource<T> loading(@Nullable T data, @Nullable String message) {
+        return new Resource<>(Status.LOADING, data, message);
+    }
+
+    @Override
+    public String toString() {
+        return "Resource{ address=" + Integer.toHexString(hashCode()) +
+                ", status=" + status +
+                ", message='" + message + '\'' +
+                '}';
     }
 }

--- a/app/src/main/java/com/bzh/dytt/home/LoadableMoviePageViewModel.java
+++ b/app/src/main/java/com/bzh/dytt/home/LoadableMoviePageViewModel.java
@@ -1,6 +1,7 @@
 package com.bzh.dytt.home;
 
 
+import android.arch.core.util.Function;
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.Transformations;
 
@@ -43,14 +44,17 @@ public class LoadableMoviePageViewModel extends BaseViewModel {
     }
 
     private void createMovieList() {
-        videoList = Transformations.switchMap(mDataRepository.getMovieListByCategory(mCategory), categoryMaps -> {
-            List<String> linkList = new ArrayList<>();
-            if (categoryMaps != null && categoryMaps.data != null) {
-                for (CategoryMap categoryMap : categoryMaps.data) {
-                    linkList.add(categoryMap.getLink());
+        videoList = Transformations.switchMap(mDataRepository.getMovieListByCategory(mCategory), new Function<Resource<List<CategoryMap>>, LiveData<Resource<List<VideoDetail>>>>() {
+            @Override
+            public LiveData<Resource<List<VideoDetail>>> apply(Resource<List<CategoryMap>> categoryMaps) {
+                List<String> linkList = new ArrayList<>();
+                if (categoryMaps != null && categoryMaps.data != null) {
+                    for (CategoryMap categoryMap : categoryMaps.data) {
+                        linkList.add(categoryMap.getLink());
+                    }
                 }
+                return mDataRepository.getVideoDetails(linkList);
             }
-            return mDataRepository.getVideoDetails(linkList);
         });
     }
 

--- a/app/src/main/java/com/bzh/dytt/home/MovieListAdapter.java
+++ b/app/src/main/java/com/bzh/dytt/home/MovieListAdapter.java
@@ -10,7 +10,6 @@ import android.support.annotation.NonNull;
 import android.support.v7.util.DiffUtil;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -46,8 +45,8 @@ public class MovieListAdapter extends RecyclerView.Adapter<MovieListAdapter.Movi
     }
 
     @Override
-    public void onBindViewHolder(@NonNull MovieListAdapter.MovieItemHolder holder, int position) {
-        VideoDetail videoDetail = mItems.get(position);
+    public void onBindViewHolder(@NonNull final MovieListAdapter.MovieItemHolder holder, int position) {
+        final VideoDetail videoDetail = mItems.get(position);
 
         if (videoDetail != null) {
             holder.VideoTitleTv.setText(Objects.equals(videoDetail.getCountry(), "中国") ? videoDetail.getName() : videoDetail.getTranslationName());
@@ -61,12 +60,15 @@ public class MovieListAdapter extends RecyclerView.Adapter<MovieListAdapter.Movi
                     .placeholder(new ColorDrawable(Color.GRAY))
                     .into(holder.VideoCover);
 
-            holder.itemView.setOnClickListener(view -> {
-                Activity activity = getActivityByHolder(holder);
-                if (activity != null) {
-                    Intent intent = new Intent(activity, SingleActivity.class);
-                    intent.putExtra("DETAIL_LINK", videoDetail.getDetailLink());
-                    activity.startActivity(intent);
+            holder.itemView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    Activity activity = getActivityByHolder(holder);
+                    if (activity != null) {
+                        Intent intent = new Intent(activity, SingleActivity.class);
+                        intent.putExtra("DETAIL_LINK", videoDetail.getDetailLink());
+                        activity.startActivity(intent);
+                    }
                 }
             });
         }
@@ -117,7 +119,7 @@ public class MovieListAdapter extends RecyclerView.Adapter<MovieListAdapter.Movi
         }
     }
 
-    public class VideoDetailDiffCallback extends DiffUtil.Callback{
+    public class VideoDetailDiffCallback extends DiffUtil.Callback {
 
         List<VideoDetail> oldVideoDetails;
         List<VideoDetail> newVideoDetails;

--- a/app/src/main/java/com/bzh/dytt/home/NewMovieFragment.java
+++ b/app/src/main/java/com/bzh/dytt/home/NewMovieFragment.java
@@ -1,51 +1,27 @@
 package com.bzh.dytt.home;
 
 
-import android.app.Activity;
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.ViewModel;
 import android.arch.lifecycle.ViewModelProvider;
 import android.arch.lifecycle.ViewModelProviders;
-import android.graphics.Color;
-import android.graphics.drawable.ColorDrawable;
-import android.os.Build;
-import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
-import android.text.TextUtils;
-import android.util.Log;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.ImageView;
-import android.widget.TextView;
 
-import com.bzh.dytt.R;
 import com.bzh.dytt.data.VideoDetail;
 import com.bzh.dytt.data.network.Resource;
-import com.bzh.dytt.task.FetchVideoDetailTask;
-import com.bzh.dytt.util.GlideApp;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import butterknife.BindView;
-import butterknife.ButterKnife;
-
 public class NewMovieFragment extends SingleListFragment<VideoDetail> {
+
+    @Inject
+    ViewModelProvider.Factory mFactory;
 
     public static NewMovieFragment newInstance() {
         return new NewMovieFragment();
     }
-
-    @Inject
-    ViewModelProvider.Factory mFactory;
 
     @Override
     protected RecyclerView.Adapter createAdapter() {
@@ -62,7 +38,6 @@ public class NewMovieFragment extends SingleListFragment<VideoDetail> {
         return ((NewMovieViewModel) mViewModel).getNewMovieList();
     }
 
-
     @Override
     protected ViewModel createViewModel() {
         return ViewModelProviders.of(this, mFactory).get(NewMovieViewModel.class);
@@ -70,6 +45,6 @@ public class NewMovieFragment extends SingleListFragment<VideoDetail> {
 
     @Override
     protected void doRefresh() {
-        ((NewMovieViewModel) mViewModel).getNewMovieList(true).observe(this, mObserver);
+        ((NewMovieViewModel) mViewModel).refresh();
     }
 }

--- a/app/src/main/java/com/bzh/dytt/home/NewMovieViewModel.java
+++ b/app/src/main/java/com/bzh/dytt/home/NewMovieViewModel.java
@@ -1,14 +1,19 @@
 package com.bzh.dytt.home;
 
 
+import android.arch.core.util.Function;
 import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.MutableLiveData;
+import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.Transformations;
+import android.support.annotation.Nullable;
 
 import com.bzh.dytt.BaseViewModel;
 import com.bzh.dytt.DataRepository;
 import com.bzh.dytt.data.CategoryMap;
 import com.bzh.dytt.data.VideoDetail;
 import com.bzh.dytt.data.network.Resource;
+import com.bzh.dytt.data.network.Status;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,35 +22,79 @@ import javax.inject.Inject;
 
 public class NewMovieViewModel extends BaseViewModel {
 
-    private LiveData<Resource<List<VideoDetail>>> videoList;
+    private final CategoryHandler mCategoryHandler;
+
+    private LiveData<Resource<List<VideoDetail>>> mVideoList;
 
     @Inject
     NewMovieViewModel(DataRepository repository) {
         super(repository);
-        createVideoList();
+        mCategoryHandler = new CategoryHandler(mDataRepository);
+        mVideoList = Transformations.switchMap(mCategoryHandler.getCategoryMap(), new Function<Resource<List<CategoryMap>>, LiveData<Resource<List<VideoDetail>>>>() {
+            @Override
+            public LiveData<Resource<List<VideoDetail>>> apply(Resource<List<CategoryMap>> input) {
+                List<String> linkList = new ArrayList<>();
+                if (input.data != null) {
+                    for (CategoryMap categoryMap : input.data) {
+                        linkList.add(categoryMap.getLink());
+                        mDataRepository.getVideoDetailNew(categoryMap.getLink());
+                    }
+                }
+                return mDataRepository.getVideoDetails(linkList);
+            }
+        });
+
+        mCategoryHandler.refresh();
     }
 
-    LiveData<Resource<List<VideoDetail>>> getNewMovieList(boolean refresh) {
-        if (refresh) {
-            createVideoList();
-        }
-        return videoList;
+    void refresh() {
+        mCategoryHandler.refresh();
     }
 
     LiveData<Resource<List<VideoDetail>>> getNewMovieList() {
-        return getNewMovieList(false);
+        return mVideoList;
     }
 
-    private void createVideoList() {
-        videoList = Transformations.switchMap(mDataRepository.getLatestMovie(), categoryMaps -> {
-            List<String> linkList = new ArrayList<>();
-            if (categoryMaps != null && categoryMaps.data != null) {
-                for (CategoryMap categoryMap : categoryMaps.data) {
-                    linkList.add(categoryMap.getLink());
+    static class CategoryHandler implements Observer<Resource<List<CategoryMap>>> {
+
+        private MutableLiveData<Resource<List<CategoryMap>>> mCategoryMap = new MutableLiveData<>();
+
+        private LiveData<Resource<List<CategoryMap>>> mLiveData;
+
+        private DataRepository mRepository;
+
+        CategoryHandler(DataRepository repository) {
+            mRepository = repository;
+        }
+
+        @Override
+        public void onChanged(@Nullable Resource<List<CategoryMap>> result) {
+            if (result == null) {
+                unregister();
+            } else {
+                mCategoryMap.setValue(result);
+                if (result.status == Status.SUCCESS || result.status == Status.ERROR) {
+                    unregister();
                 }
             }
-            return mDataRepository.getVideoDetails(linkList);
-        });
-    }
+        }
 
+        private void unregister() {
+            if (mLiveData != null) {
+                mLiveData.removeObserver(this);
+                mLiveData = null;
+            }
+        }
+
+        void refresh() {
+            unregister();
+            mLiveData = mRepository.getLatestMovie();
+            mLiveData.observeForever(this);
+        }
+
+
+        MutableLiveData<Resource<List<CategoryMap>>> getCategoryMap() {
+            return mCategoryMap;
+        }
+    }
 }

--- a/app/src/main/java/com/bzh/dytt/home/SingleListFragment.java
+++ b/app/src/main/java/com/bzh/dytt/home/SingleListFragment.java
@@ -1,6 +1,5 @@
 package com.bzh.dytt.home;
 
-
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.ViewModel;
@@ -9,7 +8,6 @@ import android.support.annotation.Nullable;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -22,12 +20,11 @@ import java.util.List;
 
 import butterknife.BindView;
 
-public abstract class SingleListFragment<T> extends BaseFragment{
+public abstract class SingleListFragment<T> extends BaseFragment {
 
-    @Override
-    protected View doCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.single_list_page, container, false);
-    }
+    protected RecyclerView.Adapter mAdapter;
+
+    protected ViewModel mViewModel;
 
     @BindView(R.id.swipe_refresh_layout)
     SwipeRefreshLayout mSwipeRefresh;
@@ -40,17 +37,6 @@ public abstract class SingleListFragment<T> extends BaseFragment{
 
     @BindView(R.id.error_layout)
     View mError;
-
-    protected RecyclerView.Adapter mAdapter;
-
-    protected ViewModel mViewModel;
-
-    private SwipeRefreshLayout.OnRefreshListener mRefreshListener = new SwipeRefreshLayout.OnRefreshListener() {
-        @Override
-        public void onRefresh() {
-            doRefresh();
-        }
-    };
 
     protected Observer<Resource<List<T>>> mObserver = new Observer<Resource<List<T>>>() {
         @Override
@@ -71,10 +57,10 @@ public abstract class SingleListFragment<T> extends BaseFragment{
                 }
                 break;
                 case SUCCESS: {
-                    mSwipeRefresh.setRefreshing(false);
                     if (listResource.data == null || listResource.data.isEmpty()) {
                         mEmpty.setVisibility(View.VISIBLE);
                     } else {
+                        mSwipeRefresh.setRefreshing(false);
                         setListData(listResource.data);
                     }
                 }
@@ -82,6 +68,17 @@ public abstract class SingleListFragment<T> extends BaseFragment{
             }
         }
     };
+    private SwipeRefreshLayout.OnRefreshListener mRefreshListener = new SwipeRefreshLayout.OnRefreshListener() {
+        @Override
+        public void onRefresh() {
+            doRefresh();
+        }
+    };
+
+    @Override
+    protected View doCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.single_list_page, container, false);
+    }
 
     protected abstract RecyclerView.Adapter createAdapter();
 
@@ -90,7 +87,6 @@ public abstract class SingleListFragment<T> extends BaseFragment{
     protected abstract LiveData<Resource<List<T>>> getLiveData();
 
     protected abstract ViewModel createViewModel();
-
 
     @Override
     protected void doCreate(@Nullable Bundle savedInstanceState) {
@@ -108,6 +104,10 @@ public abstract class SingleListFragment<T> extends BaseFragment{
         mRecyclerView.setAdapter(mAdapter);
     }
 
-    protected void doRefresh() {}
+    protected void doRefresh() {
+    }
 
+    public RecyclerView.Adapter getAdapter() {
+        return mAdapter;
+    }
 }

--- a/app/src/main/java/com/bzh/dytt/home/SingleListFragment.java
+++ b/app/src/main/java/com/bzh/dytt/home/SingleListFragment.java
@@ -22,6 +22,8 @@ import butterknife.BindView;
 
 public abstract class SingleListFragment<T> extends BaseFragment {
 
+    private static final String TAG = "SingleListFragment";
+
     protected RecyclerView.Adapter mAdapter;
 
     protected ViewModel mViewModel;
@@ -40,13 +42,13 @@ public abstract class SingleListFragment<T> extends BaseFragment {
 
     protected Observer<Resource<List<T>>> mObserver = new Observer<Resource<List<T>>>() {
         @Override
-        public void onChanged(@Nullable Resource<List<T>> listResource) {
+        public void onChanged(@Nullable Resource<List<T>> result) {
 
             mEmpty.setVisibility(View.GONE);
             mError.setVisibility(View.GONE);
 
-            assert listResource != null;
-            switch (listResource.status) {
+            assert result != null;
+            switch (result.status) {
                 case ERROR: {
                     mSwipeRefresh.setRefreshing(false);
                     mError.setVisibility(View.VISIBLE);
@@ -57,11 +59,11 @@ public abstract class SingleListFragment<T> extends BaseFragment {
                 }
                 break;
                 case SUCCESS: {
-                    if (listResource.data == null || listResource.data.isEmpty()) {
+                    mSwipeRefresh.setRefreshing(false);
+                    if (result.data == null || result.data.isEmpty()) {
                         mEmpty.setVisibility(View.VISIBLE);
                     } else {
-                        mSwipeRefresh.setRefreshing(false);
-                        setListData(listResource.data);
+                        setListData(result.data);
                     }
                 }
                 break;

--- a/app/src/main/java/com/bzh/dytt/home/VideoDetailPageFragment.java
+++ b/app/src/main/java/com/bzh/dytt/home/VideoDetailPageFragment.java
@@ -9,7 +9,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
-
+import android.support.v7.graphics.Palette;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -24,6 +24,7 @@ import com.bzh.dytt.data.VideoDetail;
 import com.bzh.dytt.data.network.Resource;
 import com.bzh.dytt.data.network.Status;
 import com.bzh.dytt.util.GlideApp;
+import com.github.florent37.glidepalette.BitmapPalette;
 import com.github.florent37.glidepalette.GlidePalette;
 
 import java.util.List;
@@ -37,6 +38,137 @@ public class VideoDetailPageFragment extends BaseFragment {
 
     private static final String TAG = "VideoDetailPageFragment";
     private static final String KEY_DETAIL_LINK = "DETAIL_LINK";
+    @Inject
+    ViewModelProvider.Factory mViewModelFactory;
+    @BindView(R.id.video_cover)
+    ImageView mVideoCoverIv;
+    @BindView(R.id.video_name)
+    TextView mVideoNameTv;
+    @BindView(R.id.video_type)
+    TextView mVideoTypeTv;
+    @BindView(R.id.video_country)
+    TextView mVideoCountryTv;
+    @BindView(R.id.video_duration)
+    TextView mVideoDuration;
+    @BindView(R.id.video_show_time)
+    TextView mVideoShowTime;
+    @BindView(R.id.video_director)
+    TextView mVideoDirector;
+    @BindView(R.id.video_leading_role)
+    TextView mVideoLeadingRole;
+    @BindView(R.id.video_description)
+    TextView mVideoDescription;
+    @BindView(R.id.video_cover_bg)
+    View mVideoCoverBgView;
+    @BindView(R.id.download_button)
+    View mDownloadBtn;
+
+    //    @BindView(R.id.video_grade_douban)
+//    TextView mRateDouban;
+//
+//    @BindView(R.id.video_grade_imdb)
+//    TextView mRateIMDB;
+    @BindView(R.id.douban_grade)
+    TextView mDoubanGradeTv;
+    @BindView(R.id.douban_rating_bar)
+    RatingBar mDoubanGradeRatingBar;
+    @BindView(R.id.imdb_grade)
+    TextView mIMDBGradeTv;
+    @BindView(R.id.imdb_rating_bar)
+    RatingBar mIMDBRatingBar;
+    @BindView(R.id.douban_rating_layout)
+    View mDoubanRatingLayout;
+    //
+//    @BindView(R.id.video_download_address)
+//    TextView mVideoDownloadAddress;
+    @BindView(R.id.imdb_rating_layout)
+    View mIMDBRatingLayout;
+    @BindView(R.id.show_time_layout)
+    View mShowTimeLayout;
+    private String mDetailLink;
+    private VideoDetailPageViewModel mVideoDetailPageViewModel;
+    private Observer<Resource<List<VideoDetail>>> mVideoDetailObserver = new Observer<Resource<List<VideoDetail>>>() {
+
+        @Override
+        public void onChanged(@Nullable Resource<List<VideoDetail>> videoDetailResource) {
+            VideoDetail videoDetail;
+            if (videoDetailResource.status == Status.SUCCESS) {
+                videoDetail = videoDetailResource.data.get(0);
+                if (videoDetail == null) {
+                    return;
+                }
+                ((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(videoDetail.getName());
+                mVideoNameTv.setText(videoDetail.getName());
+                mVideoTypeTv.setText(videoDetail.getType());
+                mVideoCountryTv.setText(videoDetail.getCountry());
+                mVideoDuration.setText(videoDetail.getDuration());
+                mVideoShowTime.setText(videoDetail.getShowTime());
+                mVideoTypeTv.setText(videoDetail.getType());
+
+                if (TextUtils.isEmpty(videoDetail.getDoubanGrade()) || Objects.equals(videoDetail.getDoubanGrade(), "0")) {
+                    mDoubanRatingLayout.setVisibility(View.GONE);
+                } else {
+                    mDoubanGradeTv.setText("豆瓣/" + videoDetail.getDoubanGrade());
+                    mDoubanGradeRatingBar.setRating(Float.parseFloat(videoDetail.getDoubanGrade()) / 2);
+                }
+
+                if (TextUtils.isEmpty(videoDetail.getIMDBGrade()) || Objects.equals(videoDetail.getIMDBGrade(), "0")) {
+                    mIMDBRatingLayout.setVisibility(View.GONE);
+                } else {
+                    mIMDBGradeTv.setText("IMDB/" + videoDetail.getIMDBGrade());
+                    mIMDBRatingBar.setRating(Float.parseFloat(videoDetail.getIMDBGrade()) / 2);
+                }
+
+                StringBuilder directorStrBuilder = new StringBuilder();
+                for (String director : videoDetail.getDirector()) {
+                    directorStrBuilder.append(director);
+                    directorStrBuilder.append(" ");
+                }
+                mVideoDirector.setText(directorStrBuilder.toString());
+
+                StringBuilder leadingRoleStrBuilder = new StringBuilder();
+                for (String director : videoDetail.getLeadingRole()) {
+                    leadingRoleStrBuilder.append(director);
+                    leadingRoleStrBuilder.append(" ");
+                }
+                mVideoLeadingRole.setText(leadingRoleStrBuilder.toString());
+                mVideoDescription.setText(videoDetail.getDescription());
+                mVideoDescription.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        if (((TextView) view).getMaxLines() > 4) {
+                            ((TextView) view).setMaxLines(4);
+                        } else {
+                            ((TextView) view).setMaxLines(100);
+                        }
+                    }
+                });
+
+                mDownloadBtn.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+
+                    }
+                });
+
+                if (TextUtils.isEmpty(videoDetail.getShowTime())) {
+                    mShowTimeLayout.setVisibility(View.GONE);
+                }
+
+                GlideApp.with(VideoDetailPageFragment.this)
+                        .load(videoDetail.getCoverUrl())
+                        .listener(GlidePalette.with(videoDetail.getCoverUrl()).use(GlidePalette.Profile.MUTED_DARK)
+                                .intoBackground(mVideoCoverBgView).crossfade(true).intoCallBack(new BitmapPalette.CallBack() {
+                                    @Override
+                                    public void onPaletteLoaded(@Nullable Palette palette) {
+                                        ((AppCompatActivity) getActivity()).getSupportActionBar().setBackgroundDrawable(new ColorDrawable(palette.getDarkMutedColor(Color.WHITE)));
+                                    }
+                                }))
+                        .placeholder(R.drawable.default_video)
+                        .into(mVideoCoverIv);
+            }
+        }
+    };
 
     public static VideoDetailPageFragment newInstance(String detailLink) {
         Bundle args = new Bundle();
@@ -45,14 +177,6 @@ public class VideoDetailPageFragment extends BaseFragment {
         fragment.setArguments(args);
         return fragment;
     }
-
-    private String mDetailLink;
-
-    @Inject
-    ViewModelProvider.Factory mViewModelFactory;
-
-    private VideoDetailPageViewModel mVideoDetailPageViewModel;
-
 
     @Override
     protected void doCreate(@Nullable Bundle savedInstanceState) {
@@ -73,141 +197,4 @@ public class VideoDetailPageFragment extends BaseFragment {
         mVideoDetailPageViewModel.getVideoDetail(mDetailLink).observe(this, mVideoDetailObserver);
 
     }
-
-    private Observer<Resource<List<VideoDetail>>> mVideoDetailObserver = new Observer<Resource<List<VideoDetail>>>() {
-
-        @Override
-        public void onChanged(@Nullable Resource<List<VideoDetail>> videoDetailResource) {
-            VideoDetail videoDetail;
-            if (videoDetailResource.status == Status.SUCCESS) {
-                videoDetail = videoDetailResource.data.get(0);
-                if (videoDetail == null) {
-                    return;
-                }
-                ((AppCompatActivity)getActivity()).getSupportActionBar().setTitle(videoDetail.getName());
-                mVideoNameTv.setText(videoDetail.getName());
-                mVideoTypeTv.setText(videoDetail.getType());
-                mVideoCountryTv.setText(videoDetail.getCountry());
-                mVideoDuration.setText(videoDetail.getDuration());
-                mVideoShowTime.setText(videoDetail.getShowTime());
-                mVideoTypeTv.setText(videoDetail.getType());
-
-                if (TextUtils.isEmpty(videoDetail.getDoubanGrade()) || Objects.equals(videoDetail.getDoubanGrade(), "0")) {
-                    mDoubanRatingLayout.setVisibility(View.GONE);
-                } else {
-                    mDoubanGradeTv.setText("豆瓣/" + videoDetail.getDoubanGrade());
-                    mDoubanGradeRatingBar.setRating(Float.parseFloat(videoDetail.getDoubanGrade())/2);
-                }
-
-                if (TextUtils.isEmpty(videoDetail.getIMDBGrade()) || Objects.equals(videoDetail.getIMDBGrade(), "0")) {
-                    mIMDBRatingLayout.setVisibility(View.GONE);
-                } else {
-                    mIMDBGradeTv.setText("IMDB/" + videoDetail.getIMDBGrade());
-                    mIMDBRatingBar.setRating(Float.parseFloat(videoDetail.getIMDBGrade())/2);
-                }
-
-                StringBuilder directorStrBuilder = new StringBuilder();
-                for (String director : videoDetail.getDirector()) {
-                    directorStrBuilder.append(director);
-                    directorStrBuilder.append(" ");
-                }
-                mVideoDirector.setText(directorStrBuilder.toString());
-
-                StringBuilder leadingRoleStrBuilder = new StringBuilder();
-                for (String director : videoDetail.getLeadingRole()) {
-                    leadingRoleStrBuilder.append(director);
-                    leadingRoleStrBuilder.append(" ");
-                }
-                mVideoLeadingRole.setText(leadingRoleStrBuilder.toString());
-                mVideoDescription.setText(videoDetail.getDescription());
-                mVideoDescription.setOnClickListener(view -> {
-                    if (((TextView) view).getMaxLines() > 4) {
-                        ((TextView) view).setMaxLines(4);
-                    } else {
-                        ((TextView) view).setMaxLines(100);
-                    }
-                });
-
-                mDownloadBtn.setOnClickListener(view -> {
-
-                });
-
-                if(TextUtils.isEmpty(videoDetail.getShowTime())) {
-                    mShowTimeLayout.setVisibility(View.GONE);
-                }
-
-                GlideApp.with(VideoDetailPageFragment.this)
-                        .load(videoDetail.getCoverUrl())
-                        .listener(GlidePalette.with(videoDetail.getCoverUrl()).use(GlidePalette.Profile.MUTED_DARK)
-                                .intoBackground(mVideoCoverBgView).crossfade(true).intoCallBack(palette -> {
-                                    ((AppCompatActivity)getActivity()).getSupportActionBar().setBackgroundDrawable(new ColorDrawable(palette.getDarkMutedColor(Color.WHITE)));
-                                }))
-                        .placeholder(R.drawable.default_video)
-                        .into(mVideoCoverIv);
-            }
-        }
-    };
-
-    @BindView(R.id.video_cover)
-    ImageView mVideoCoverIv;
-
-    @BindView(R.id.video_name)
-    TextView mVideoNameTv;
-
-    @BindView(R.id.video_type)
-    TextView mVideoTypeTv;
-
-    @BindView(R.id.video_country)
-    TextView mVideoCountryTv;
-
-//    @BindView(R.id.video_grade_douban)
-//    TextView mRateDouban;
-//
-//    @BindView(R.id.video_grade_imdb)
-//    TextView mRateIMDB;
-
-    @BindView(R.id.video_duration)
-    TextView mVideoDuration;
-
-    @BindView(R.id.video_show_time)
-    TextView mVideoShowTime;
-
-    @BindView(R.id.video_director)
-    TextView mVideoDirector;
-
-    @BindView(R.id.video_leading_role)
-    TextView mVideoLeadingRole;
-
-    @BindView(R.id.video_description)
-    TextView mVideoDescription;
-//
-//    @BindView(R.id.video_download_address)
-//    TextView mVideoDownloadAddress;
-
-    @BindView(R.id.video_cover_bg)
-    View mVideoCoverBgView;
-
-    @BindView(R.id.download_button)
-    View mDownloadBtn;
-
-    @BindView(R.id.douban_grade)
-    TextView mDoubanGradeTv;
-
-    @BindView(R.id.douban_rating_bar)
-    RatingBar mDoubanGradeRatingBar;
-
-    @BindView(R.id.imdb_grade)
-    TextView mIMDBGradeTv;
-
-    @BindView(R.id.imdb_rating_bar)
-    RatingBar mIMDBRatingBar;
-
-    @BindView(R.id.douban_rating_layout)
-    View mDoubanRatingLayout;
-
-    @BindView(R.id.imdb_rating_layout)
-    View mIMDBRatingLayout;
-
-    @BindView(R.id.show_time_layout)
-    View mShowTimeLayout;
 }

--- a/app/src/main/java/com/bzh/dytt/task/FetchVideoDetailTask.java
+++ b/app/src/main/java/com/bzh/dytt/task/FetchVideoDetailTask.java
@@ -1,7 +1,6 @@
 package com.bzh.dytt.task;
 
 
-import android.provider.MediaStore;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -36,9 +35,9 @@ public class FetchVideoDetailTask implements Runnable {
             Response<ResponseBody> response = mService.getVideoDetailNew(mVideoDetailLink).execute();
             ApiResponse<ResponseBody> apiResponse = new ApiResponse<>(response);
 
-            if(apiResponse.isSuccessful()) {
+            if (apiResponse.isSuccessful()) {
                 VideoDetail videoDetail = mParser.parseVideoDetail(new String(apiResponse.body.bytes(), "GB2312"));
-                if(TextUtils.isEmpty(videoDetail.getName())){
+                if (TextUtils.isEmpty(videoDetail.getName())) {
                     videoDetail.setValidVideoItem(false);
                 } else {
                     videoDetail.setValidVideoItem(true);

--- a/app/src/main/java/com/bzh/dytt/util/AbsentLiveData.java
+++ b/app/src/main/java/com/bzh/dytt/util/AbsentLiveData.java
@@ -1,0 +1,19 @@
+package com.bzh.dytt.util;
+
+
+import android.arch.lifecycle.LiveData;
+
+/**
+ * A LiveData class that has {@code null} value.
+ */
+public class AbsentLiveData extends LiveData {
+
+    private AbsentLiveData() {
+        postValue(null);
+    }
+
+    public static <T> LiveData<T> create() {
+        //noinspection unchecked
+        return new AbsentLiveData();
+    }
+}

--- a/app/src/main/java/com/bzh/dytt/util/AutoClearedValue.java
+++ b/app/src/main/java/com/bzh/dytt/util/AutoClearedValue.java
@@ -21,22 +21,25 @@ import android.support.v4.app.FragmentManager;
 
 /**
  * A value holder that automatically clears the reference if the Fragment's view is destroyed.
+ *
  * @param <T>
  */
 public class AutoClearedValue<T> {
     private T value;
-    public AutoClearedValue(Fragment fragment, T value) {
-        FragmentManager fragmentManager = fragment.getFragmentManager();
-        fragmentManager.registerFragmentLifecycleCallbacks(
-                new FragmentManager.FragmentLifecycleCallbacks() {
-                    @Override
-                    public void onFragmentViewDestroyed(FragmentManager fm, Fragment f) {
-                        if (f == fragment) {
-                            AutoClearedValue.this.value = null;
-                            fragmentManager.unregisterFragmentLifecycleCallbacks(this);
-                        }
+
+    public AutoClearedValue(final Fragment fragment, T value) {
+        final FragmentManager fragmentManager = fragment.getFragmentManager();
+        if (fragmentManager != null) {
+            fragmentManager.registerFragmentLifecycleCallbacks(new FragmentManager.FragmentLifecycleCallbacks() {
+                @Override
+                public void onFragmentViewDestroyed(FragmentManager fm, Fragment f) {
+                    if (f == fragment) {
+                        AutoClearedValue.this.value = null;
+                        fragmentManager.unregisterFragmentLifecycleCallbacks(this);
                     }
-                },false);
+                }
+            }, false);
+        }
         this.value = value;
     }
 


### PR DESCRIPTION
1. 格式化了部分代码
2. 修改了`NewMovieViewModel`类中有关数据刷新的逻辑，将UI变更的`LiveData`与数据刷新隔离开。
3. 移除了Java8的表达式支持，原因是缩写会省略一部分信息，导致逻辑不容易被看清楚。